### PR TITLE
Disable pre-install check until we can reliably detect available updates

### DIFF
--- a/libraries/provider_steamcmd.rb
+++ b/libraries/provider_steamcmd.rb
@@ -5,7 +5,8 @@ class Chef
     class Steamcmd < Chef::Provider
 
       def load_current_resource
-        @exists = directory_exists?(new_resource.path)
+        # @exists = directory_exists?(new_resource.path)
+        @exists = false
       end
 
       def action_install


### PR DESCRIPTION
Need to spike on determining whether an update is available.
